### PR TITLE
Removed unused private method toDegrees

### DIFF
--- a/jme3-android-examples/src/main/java/jme3test/android/TestAndroidSensors.java
+++ b/jme3-android-examples/src/main/java/jme3test/android/TestAndroidSensors.java
@@ -79,10 +79,6 @@ public class TestAndroidSensors extends SimpleApplication implements ActionListe
 
     // Make sure to set joystickEventsEnabled = true in MainActivity for Android
 
-    private float toDegrees(float rad) {
-        return rad * FastMath.RAD_TO_DEG;
-    }
-
     @Override
     public void simpleInitApp() {
 


### PR DESCRIPTION
**Summary**

- This pull request removes the unused toDegrees method from TestAndroidSensors.java, as it was identified as technical debt.

**Changes Made**

**- Deleted:** The private method toDegrees(float rad) from TestAndroidSensors.java.
**- Reason:** The method was unused in the codebase and contributed to unnecessary complexity.

**Technical Debt Addressed**

- Improves code maintainability by reducing unnecessary methods.
- Reduces code clutter and ensures only relevant functions remain.
- Aligns with best practices for clean and efficient code.