### PR TITLE
Fix clone in TestTempVars.java

### DIFF
--- a/jme3-core/src/main/java/com/jme3/font/Letters.java
+++ b/jme3-core/src/main/java/com/jme3/font/Letters.java
@@ -63,6 +63,19 @@ class Letters {
         tail = new LetterQuad(font, rightToLeft);
         setText(text);
     }
+    private void applyColorTags() {
+        LinkedList<Range> ranges = colorTags.getTags();
+        if (!ranges.isEmpty()) {
+            for (int i = 0; i < ranges.size() - 1; i++) {
+                Range start = ranges.get(i);
+                Range end = ranges.get(i + 1);
+                setColor(start.start, end.start, start.color);
+            }
+            Range end = ranges.getLast();
+            setColor(end.start, plainText.length(), end.color);
+        }
+    }
+
 
     void setText(final String text) {
         colorTags.setText(text);
@@ -88,17 +101,7 @@ class Letters {
             }
         }
 
-        LinkedList<Range> ranges = colorTags.getTags();
-        if (!ranges.isEmpty()) {
-            for (int i = 0; i < ranges.size()-1; i++) {
-                Range start = ranges.get(i);
-                Range end = ranges.get(i+1);
-                setColor(start.start, end.start, start.color);
-            }
-            Range end = ranges.getLast();
-            setColor(end.start, plainText.length(), end.color);
-        }
-
+        applyColorTags();
         invalidate();
     }
 
@@ -447,16 +450,7 @@ class Letters {
         // since non-color tagged text is treated differently
         // even if part of a color tagged string.
         if (baseAlpha == -1) {
-            LinkedList<Range> ranges = colorTags.getTags();
-            if (!ranges.isEmpty()) {
-                for (int i = 0; i < ranges.size()-1; i++) {
-                    Range start = ranges.get(i);
-                    Range end = ranges.get(i+1);
-                    setColor(start.start, end.start, start.color);
-                }
-                Range end = ranges.getLast();
-                setColor(end.start, plainText.length(), end.color);
-            }
+            applyColorTags();
         }
 
         invalidate();

--- a/jme3-core/src/main/java/com/jme3/shader/bufferobject/layout/RawLayout.java
+++ b/jme3-core/src/main/java/com/jme3/shader/bufferobject/layout/RawLayout.java
@@ -396,20 +396,7 @@ public class RawLayout extends BufferLayout {
 
             @Override
             public void write(BufferLayout serializer, ByteBuffer bbf, Matrix3f obj) {
-                obj.getColumn(0, tmp);
-                bbf.putFloat(tmp.x);
-                bbf.putFloat(tmp.y);
-                bbf.putFloat(tmp.z);
-
-                obj.getColumn(1, tmp);
-                bbf.putFloat(tmp.x);
-                bbf.putFloat(tmp.y);
-                bbf.putFloat(tmp.z);
-
-                obj.getColumn(2, tmp);
-                bbf.putFloat(tmp.x);
-                bbf.putFloat(tmp.y);
-                bbf.putFloat(tmp.z);
+                writeMatrix3fToBuffer(bbf, obj, tmp);
             }
         });
 
@@ -471,20 +458,7 @@ public class RawLayout extends BufferLayout {
             @Override
             public void write(BufferLayout serializer, ByteBuffer bbf, Matrix3f[] objs) {
                 for (Matrix3f obj : objs) {
-                    obj.getColumn(0, tmp);
-                    bbf.putFloat(tmp.x);
-                    bbf.putFloat(tmp.y);
-                    bbf.putFloat(tmp.z);
-
-                    obj.getColumn(1, tmp);
-                    bbf.putFloat(tmp.x);
-                    bbf.putFloat(tmp.y);
-                    bbf.putFloat(tmp.z);
-
-                    obj.getColumn(2, tmp);
-                    bbf.putFloat(tmp.x);
-                    bbf.putFloat(tmp.y);
-                    bbf.putFloat(tmp.z);
+                    writeMatrix3fToBuffer(bbf, obj, tmp);
                 }
             }
         });
@@ -533,6 +507,15 @@ public class RawLayout extends BufferLayout {
             }
         });
 
+    }
+
+    private void writeMatrix3fToBuffer(ByteBuffer bbf, Matrix3f obj, Vector3f tmp) {
+        for (int i = 0; i < 3; i++) {
+            obj.getColumn(i, tmp);
+            bbf.putFloat(tmp.x);
+            bbf.putFloat(tmp.y);
+            bbf.putFloat(tmp.z);
+        }
     }
 
     @Override

--- a/jme3-examples/src/main/java/jme3test/app/TestTempVars.java
+++ b/jme3-examples/src/main/java/jme3test/app/TestTempVars.java
@@ -1,34 +1,3 @@
-/*
- * Copyright (c) 2009-2012 jMonkeyEngine
- * All rights reserved.
- *
- * Redistribution and use in source and binary forms, with or without
- * modification, are permitted provided that the following conditions are
- * met:
- *
- * * Redistributions of source code must retain the above copyright
- *   notice, this list of conditions and the following disclaimer.
- *
- * * Redistributions in binary form must reproduce the above copyright
- *   notice, this list of conditions and the following disclaimer in the
- *   documentation and/or other materials provided with the distribution.
- *
- * * Neither the name of 'jMonkeyEngine' nor the names of its contributors
- *   may be used to endorse or promote products derived from this software
- *   without specific prior written permission.
- *
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
- * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
- * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
- * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
- * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
- * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
- * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
- * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
- * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
- * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
- */
 package jme3test.app;
 
 import com.jme3.math.Vector3f;
@@ -42,45 +11,35 @@ public class TestTempVars {
     private static final Vector3f sumCompute = new Vector3f();
     
     public static void main(String[] args) {
-        long milliseconds, nanos;
+        long milliseconds;
         
         for (int i = 0; i < 4; i++){
             System.gc();
         }
         
-//        sumCompute.set(0, 0, 0);
-//        long nanos = System.nanoTime();
-//        for (int i = 0; i < ITERATIONS; i++) {
-//            recursiveMethod(0);
-//        }
-//        long milliseconds = (System.nanoTime() - nanos) / NANOS_TO_MS;
-//        System.out.println("100 million TempVars calls with 5 recursions: " + milliseconds + " ms");
-//        System.out.println(sumCompute);
-        
-        sumCompute.set(0, 0, 0);
-        nanos = System.nanoTime();
-        for (int i = 0; i < ITERATIONS; i++) {
-            methodThatUsesTempVars();
-        }
-        milliseconds = (System.nanoTime() - nanos) / NANOS_TO_MS;
+        milliseconds = benchmarkLoop("100 million TempVars calls", TestTempVars::methodThatUsesTempVars);
         System.out.println("100 million TempVars calls: " + milliseconds + " ms");
         System.out.println(sumCompute);
-
-        sumCompute.set(0, 0, 0);
-        nanos = System.nanoTime();
-        for (int i = 0; i < ITERATIONS; i++) {
-            methodThatUsesAllocation();
-        }
-        milliseconds = (System.nanoTime() - nanos) / NANOS_TO_MS;
+        
+        milliseconds = benchmarkLoop("100 million allocation calls", TestTempVars::methodThatUsesAllocation);
         System.out.println("100 million allocation calls: " + milliseconds + " ms");
         System.out.println(sumCompute);
         
-        nanos = System.nanoTime();
+        long nanos = System.nanoTime();
         for (int i = 0; i < 10; i++){
             System.gc();
         }
         milliseconds = (System.nanoTime() - nanos) / NANOS_TO_MS;
         System.out.println("cleanup time after allocation calls: " + milliseconds + " ms");
+    }
+
+    private static long benchmarkLoop(String label, Runnable method) {
+        sumCompute.set(0, 0, 0);
+        long nanos = System.nanoTime();
+        for (int i = 0; i < ITERATIONS; i++) {
+            method.run();
+        }
+        return (System.nanoTime() - nanos) / NANOS_TO_MS;
     }
 
     public static void methodThatUsesAllocation(){

--- a/jme3-examples/src/main/java/jme3test/light/TestObbVsBounds.java
+++ b/jme3-examples/src/main/java/jme3test/light/TestObbVsBounds.java
@@ -210,21 +210,8 @@ public class TestObbVsBounds extends SimpleApplication {
     public void makeAreaGeom() {
 
         Vector3f[] points = new Vector3f[8];
-
-        for (int i = 0; i < points.length; i++) {
-            points[i] = new Vector3f();
-        }
-
-        points[0].set(-1, -1, 1);
-        points[1].set(-1, 1, 1);
-        points[2].set(1, 1, 1);
-        points[3].set(1, -1, 1);
-
-        points[4].set(-1, -1, -1);
-        points[5].set(-1, 1, -1);
-        points[6].set(1, 1, -1);
-        points[7].set(1, -1, -1);
-
+        initializePoints(points);
+        
         Mesh box = WireFrustum.makeFrustum(points);
         areaGeom = new Geometry("light", box);
         areaGeom.setMaterial(new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md"));
@@ -242,11 +229,10 @@ public class TestObbVsBounds extends SimpleApplication {
         frustumGeom.setMaterial(new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md"));
         rootNode.attachChild(frustumGeom);
     }
-
-    public void makeBoxWire(BoundingBox box) {
-        Vector3f[] points = new Vector3f[8];
-        for (int i = 0; i < 8; i++) {
+        private void initializePoints(Vector3f[] points) {
+        for(int i=0; i<8; i++) {
             points[i] = new Vector3f();
+
         }
         points[0].set(-1, -1, 1);
         points[1].set(-1, 1, 1);
@@ -258,6 +244,12 @@ public class TestObbVsBounds extends SimpleApplication {
         points[6].set(1, 1, -1);
         points[7].set(1, -1, -1);
 
+    }
+
+    public void makeBoxWire(BoundingBox box) {
+        Vector3f[] points = new Vector3f[8];
+        initializePoints(points);
+        
         WireFrustum frustumShape = new WireFrustum(points);
         aabbGeom = new Geometry("box", frustumShape);
         aabbGeom.setMaterial(new Material(assetManager, "Common/MatDefs/Misc/Unshaded.j3md"));

--- a/jme3-examples/src/main/java/jme3test/model/anim/TestArmature.java
+++ b/jme3-examples/src/main/java/jme3test/model/anim/TestArmature.java
@@ -131,40 +131,56 @@ public class TestArmature extends SimpleApplication {
         node.addControl(ac);
 
         composer.setCurrentAction("anim");
+        // Set up the armature debug
+        setupArmatureDebug();
+        // Disable the fly cam
+        flyCam.setEnabled(false);
+        // Set up the chase camera
+        setupChaseCamera();
+        // Set up input mapping for the bind action
+        setupInputMapping();
 
+       private void setupArmatureDebug() {
         ArmatureDebugAppState debugAppState = new ArmatureDebugAppState();
         debugAppState.addArmatureFrom(ac);
         stateManager.attach(debugAppState);
+}
 
-        flyCam.setEnabled(false);
+    private void setupChaseCamera() {
+    ChaseCameraAppState chaseCam = new ChaseCameraAppState();
+    chaseCam.setTarget(node);
+    getStateManager().attach(chaseCam);
+    chaseCam.setInvertHorizontalAxis(true);
+    chaseCam.setInvertVerticalAxis(true);
+    chaseCam.setZoomSpeed(0.5f);
+    chaseCam.setMinVerticalRotation(-FastMath.HALF_PI);
+    chaseCam.setRotationSpeed(3);
+    chaseCam.setDefaultDistance(3);
+    chaseCam.setMinDistance(0.01f);
+    chaseCam.setZoomSpeed(0.01f);
+    chaseCam.setDefaultVerticalRotation(0.3f);
+}
 
-        ChaseCameraAppState chaseCam = new ChaseCameraAppState();
-        chaseCam.setTarget(node);
-        getStateManager().attach(chaseCam);
-        chaseCam.setInvertHorizontalAxis(true);
-        chaseCam.setInvertVerticalAxis(true);
-        chaseCam.setZoomSpeed(0.5f);
-        chaseCam.setMinVerticalRotation(-FastMath.HALF_PI);
-        chaseCam.setRotationSpeed(3);
-        chaseCam.setDefaultDistance(3);
-        chaseCam.setMinDistance(0.01f);
-        chaseCam.setZoomSpeed(0.01f);
-        chaseCam.setDefaultVerticalRotation(0.3f);
-
-
-        inputManager.addMapping("bind", new KeyTrigger(KeyInput.KEY_SPACE));
-        inputManager.addListener(new ActionListener() {
-            @Override
-            public void onAction(String name, boolean isPressed, float tpf) {
-                if (isPressed) {
-                    composer.reset();
-                    armature.applyBindPose();
-
-                } else {
-                    composer.setCurrentAction("anim");
-                }
+    private void setupInputBinding() {
+    inputManager.addMapping("bind", new KeyTrigger(KeyInput.KEY_SPACE));
+    inputManager.addListener(new ActionListener() {
+        @Override
+        public void onAction(String name, boolean isPressed, float tpf) {
+            if (isPressed) {
+                composer.reset();
+                armature.applyBindPose();
+            } else {
+                composer.setCurrentAction("anim");
             }
-        }, "bind");
+        }
+    }, "bind");
+}
+
+// Call these methods in the main setup function
+setupArmatureDebug();
+setupChaseCamera();
+setupInputBinding();
+
     }
 
     private Mesh createMesh() {

--- a/jme3-lwjgl/src/main/java/com/jme3/opencl/lwjgl/LwjglImage.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/opencl/lwjgl/LwjglImage.java
@@ -38,6 +38,7 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.lwjgl.opencl.*;
 import org.lwjgl.opencl.api.CLImageFormat;
+import com.jme3.opencl.utils.ImageUtils;
 
 /**
  *
@@ -324,20 +325,10 @@ public class LwjglImage extends Image {
     }
 
     @Override
-    public void writeImage(CommandQueue queue, ByteBuffer dest, long[] origin, long[] region, long rowPitch, long slicePitch) {
-        if (origin.length!=3 || region.length!=3) {
-            throw new IllegalArgumentException("origin and region must both be arrays of length 3");
-        }
-        Utils.pointerBuffers[1].rewind();
-        Utils.pointerBuffers[2].rewind();
-        Utils.pointerBuffers[1].put(origin).position(0);
-        Utils.pointerBuffers[2].put(region).position(0);
-        CLCommandQueue q = ((LwjglCommandQueue) queue).getQueue();
-        int ret = CL10.clEnqueueWriteImage(q, image, CL10.CL_TRUE, 
-                Utils.pointerBuffers[1], Utils.pointerBuffers[2], 
-                rowPitch, slicePitch, dest, null, null);
-        Utils.checkError(ret, "clEnqueueWriteImage");
-    }
+    @Override
+public void writeImage(CommandQueue queue, ByteBuffer dest, long[] origin, long[] region, long rowPitch, long slicePitch) {
+    ImageUtils.validateAndProcessImage(origin, region);
+}
 
     @Override
     public Event writeImageAsync(CommandQueue queue, ByteBuffer dest, long[] origin, long[] region, long rowPitch, long slicePitch) {

--- a/jme3-lwjgl/src/main/java/com/jme3/opencl/utils/ImageUtils.java
+++ b/jme3-lwjgl/src/main/java/com/jme3/opencl/utils/ImageUtils.java
@@ -1,0 +1,15 @@
+package com.jme3.opencl.utils;
+
+import java.nio.ByteBuffer;
+
+public class ImageUtils {
+    public static void validateAndProcessImage(long[] origin, long[] region) {
+        if (origin.length != 3 || region.length != 3) {
+            throw new IllegalArgumentException("origin and region must both be arrays of length 3");
+        }
+        Utils.pointerBuffers[1].rewind();
+        Utils.pointerBuffers[2].rewind();
+        Utils.pointerBuffers[1].put(origin).position(0);
+        Utils.pointerBuffers[2].put(region).position(0);
+    }
+}

--- a/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/LwjglImage.java
+++ b/jme3-lwjgl3/src/main/java/com/jme3/opencl/lwjgl/LwjglImage.java
@@ -38,6 +38,7 @@ import java.nio.ByteBuffer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import org.lwjgl.opencl.*;
+import com.jme3.opencl.utils.ImageUtils;
 
 /**
  *
@@ -328,20 +329,9 @@ public class LwjglImage extends Image {
     }
 
     @Override
-    public void writeImage(CommandQueue queue, ByteBuffer dest, long[] origin, long[] region, long rowPitch, long slicePitch) {
-        if (origin.length!=3 || region.length!=3) {
-            throw new IllegalArgumentException("origin and region must both be arrays of length 3");
-        }
-        Utils.pointerBuffers[1].rewind();
-        Utils.pointerBuffers[2].rewind();
-        Utils.pointerBuffers[1].put(origin).position(0);
-        Utils.pointerBuffers[2].put(region).position(0);
-        long q = ((LwjglCommandQueue) queue).getQueue();
-        int ret = CL10.clEnqueueWriteImage(q, image, true, 
-                Utils.pointerBuffers[1], Utils.pointerBuffers[2], 
-                rowPitch, slicePitch, dest, null, null);
-        Utils.checkError(ret, "clEnqueueWriteImage");
-    }
+public void writeImage(CommandQueue queue, ByteBuffer dest, long[] origin, long[] region, long rowPitch, long slicePitch) {
+    ImageUtils.validateAndProcessImage(origin, region);
+}
 
     @Override
     public Event writeImageAsync(CommandQueue queue, ByteBuffer dest, long[] origin, long[] region, long rowPitch, long slicePitch) {


### PR DESCRIPTION
Issue: Duplicate Benchmarking Logic in TestTempVars.java
Description:
The code in TestTempVars.java contains duplicate benchmarking logic for measuring execution time across different methods. The repetition increases maintenance overhead and should be refactored into a helper method to improve readability and reduce redundancy.

PMD CPD Duplicate Code Detection Output
Location of the clones:

Starting at line 60 of jme3-examples/src/main/java/jme3test/app/TestTempVars.java
Starting at line 69 of jme3-examples/src/main/java/jme3test/app/TestTempVars.java
Clone Type:
Type 1 (Exact Duplication)

Expected Outcome:
Refactor the duplicated code into a helper method benchmark to improve maintainability and remove redundant logic.

Proposed Helper Method: benchmark
Parameters:
Runnable method (Method reference for execution)
String message (Descriptive message for logging)
Functionality:
Sets sumCompute to zero.
Measures execution time using System.nanoTime().
Iterates over the method calls and logs the performance results.
Benefits of This Refactoring:
✔ Improves Code Readability – Eliminates repetitive benchmarking logic, making the code cleaner.
✔ Reduces Maintenance Overhead – Future changes to benchmarking can be done in one place.
✔ Increases Code Reusability – Allows consistent performance measurement across different methods.