### PR TITLE
Fix security vulnerability: replace printStackTrace with Logger in IrradianceSphericalHarmonicsGenerator

### DIFF
--- a/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/SceneLoader.java
+++ b/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/SceneLoader.java
@@ -526,6 +526,13 @@ public class SceneLoader extends DefaultHandler implements AssetLoader {
             // checking with JmeSystem.
             SAXParserFactory factory = SAXParserFactory.newInstance();
             factory.setNamespaceAware(true);
+            try {
+                factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+                factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+                factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            } catch (ParserConfigurationException | SAXException ex) {
+                throw new RuntimeException("Failed to set secure parser features", ex);
+            }
             XMLReader xr = factory.newSAXParser().getXMLReader();
 
             xr.setContentHandler(this);

--- a/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/SceneMaterialLoader.java
+++ b/jme3-plugins/src/ogre/java/com/jme3/scene/plugins/ogre/SceneMaterialLoader.java
@@ -125,10 +125,16 @@ class SceneMaterialLoader extends DefaultHandler {
             this.folderName = folderName;
             
             reset();
-            
+
             SAXParserFactory factory = SAXParserFactory.newInstance();
-            factory.setNamespaceAware(true);  
-            XMLReader xr = factory.newSAXParser().getXMLReader();  
+            factory.setNamespaceAware(true);
+
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+
+            XMLReader xr = factory.newSAXParser().getXMLReader();
 
             xr.setContentHandler(this);
             xr.setErrorHandler(this);

--- a/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
+++ b/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
@@ -79,7 +79,16 @@ public class XMLExporter implements JmeExporter {
     public void save(Savable object, OutputStream outputStream) throws IOException {
         Document document = null;
         try {
-            document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            // XXE Protection for Document Builder
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            dbf.setXIncludeAware(false);
+            dbf.setExpandEntityReferences(false);
+
+            document = dbf.newDocumentBuilder().newDocument();
         } catch (ParserConfigurationException ex) {
             throw new IOException(ex);
         }
@@ -95,6 +104,10 @@ public class XMLExporter implements JmeExporter {
 
         try {
             TransformerFactory tfFactory = TransformerFactory.newInstance();
+            // XXE Protection for Transformer
+            tfFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            tfFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            tfFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             tfFactory.setAttribute("indent-number", indentSpaces);
 
             Transformer transformer = tfFactory.newTransformer();

--- a/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
+++ b/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
@@ -40,7 +40,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import org.w3c.dom.Document;
-import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
@@ -78,20 +77,9 @@ public class XMLExporter implements JmeExporter {
 
     @Override
     public void save(Savable object, OutputStream outputStream) throws IOException {
-        Document document;
+        Document document = null;
         try {
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            // Disable DTDs entirely
-            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            // Disable external entities
-            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-            // Enable secure processing
-            dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-
-            document = dbf.newDocumentBuilder().newDocument();
-            document.setXmlStandalone(true);
+            document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
         } catch (ParserConfigurationException ex) {
             throw new IOException(ex);
         }

--- a/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
+++ b/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
@@ -40,6 +40,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import org.w3c.dom.Document;
+import javax.xml.XMLConstants;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.Transformer;
@@ -77,9 +78,20 @@ public class XMLExporter implements JmeExporter {
 
     @Override
     public void save(Savable object, OutputStream outputStream) throws IOException {
-        Document document = null;
+        Document document;
         try {
-            document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            // Disable DTDs entirely
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            // Disable external entities
+            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            // Enable secure processing
+            dbf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+
+            document = dbf.newDocumentBuilder().newDocument();
+            document.setXmlStandalone(true);
         } catch (ParserConfigurationException ex) {
             throw new IOException(ex);
         }

--- a/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
+++ b/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
@@ -79,13 +79,7 @@ public class XMLExporter implements JmeExporter {
     public void save(Savable object, OutputStream outputStream) throws IOException {
         Document document = null;
         try {
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            // XXE Protection for Document Builder
-            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            dbf.setXIncludeAware(false);
-            dbf.setExpandEntityReferences(false);
-
-            document = dbf.newDocumentBuilder().newDocument();
+            document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
         } catch (ParserConfigurationException ex) {
             throw new IOException(ex);
         }

--- a/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
+++ b/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
@@ -79,7 +79,13 @@ public class XMLExporter implements JmeExporter {
     public void save(Savable object, OutputStream outputStream) throws IOException {
         Document document = null;
         try {
-            document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
+            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+            // XXE Protection for Document Builder
+            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            dbf.setXIncludeAware(false);
+            dbf.setExpandEntityReferences(false);
+
+            document = dbf.newDocumentBuilder().newDocument();
         } catch (ParserConfigurationException ex) {
             throw new IOException(ex);
         }

--- a/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
+++ b/jme3-plugins/src/xml/java/com/jme3/export/xml/XMLExporter.java
@@ -79,16 +79,7 @@ public class XMLExporter implements JmeExporter {
     public void save(Savable object, OutputStream outputStream) throws IOException {
         Document document = null;
         try {
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            // XXE Protection for Document Builder
-            dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-            dbf.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            dbf.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            dbf.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-            dbf.setXIncludeAware(false);
-            dbf.setExpandEntityReferences(false);
-
-            document = dbf.newDocumentBuilder().newDocument();
+            document = DocumentBuilderFactory.newInstance().newDocumentBuilder().newDocument();
         } catch (ParserConfigurationException ex) {
             throw new IOException(ex);
         }
@@ -104,10 +95,6 @@ public class XMLExporter implements JmeExporter {
 
         try {
             TransformerFactory tfFactory = TransformerFactory.newInstance();
-            // XXE Protection for Transformer
-            tfFactory.setFeature("http://xml.org/sax/features/external-general-entities", false);
-            tfFactory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
-            tfFactory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
             tfFactory.setAttribute("indent-number", indentSpaces);
 
             Transformer transformer = tfFactory.newTransformer();


### PR DESCRIPTION
**Summary**
This pull request removes the use of printStackTrace() in IrradianceSphericalHarmonicsGenerator and replaces it with a Logger to address a security vulnerability flagged by SonarQube.

**Changes**

Removed e.printStackTrace() calls.
Added java.util.logging.Logger to log exceptions at SEVERE level.
Ensured the overall functionality remains unchanged.
**Reasoning**

printStackTrace() can reveal sensitive information in production logs.
Proper logging helps maintain security and compliance standards.